### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 警告！！本人不保证此魔改脚本可以稳定工作在所有Linux发行版上，因使用此脚本而导致的任何服务器宕机/冒烟以及数据损毁本人概不负责！
 
-提醒：此脚本需要与LNMP一键安装包（http://lnmp.org）配合使用
+提醒：此脚本需要与<a href="http://lnmp.org" target="_blank">LNMP一键安装包</a>配合使用
 
-感谢:http://lnmp.org  https://future.moe
+感谢：<a href="http://lnmp.org" target="_blank">LNMP一键安装包</a> <a href="https://www.futures.moe/" target="_blank">未来领域</a>


### PR DESCRIPTION
未来领域链接错误，Markdown语法有点混乱导致lnmp一键安装包的链接被错误解析
<s>然而我也忘了Markdown的链接语法于是就拿HTML糊弄了一下（捂脸</s>
